### PR TITLE
Docstrings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -254,4 +254,4 @@ def linkcode_resolve(domain, info):
 
     fn = os.path.relpath(fn, start=os.path.dirname(mpl_inter.__file__))
 
-    return f"https://github.com/mpl-extensions/mpl-interactions/blob/main/mpl_interactions/{fn}{linespec}"
+    return f"https://github.com/mpl-extensions/mpl-interactions/blob/main/mpl_interactions/{fn}{linespec}"  # noqa: E501

--- a/mpl_interactions/mpl_kwargs.py
+++ b/mpl_interactions/mpl_kwargs.py
@@ -61,7 +61,11 @@ Line2D_kwargs_list = [
     "zorder",
 ]
 
-imshow_kwargs_list = ArtistInspector(AxesImage).get_setters()
+imshow_kwargs_list = [
+    *ArtistInspector(AxesImage).get_setters(),
+    "aspect",  # these are arguments to imshow not captured by `get_setter`
+    "origin",
+]
 collection_kwargs_list = ArtistInspector(Collection).get_setters()
 
 Text_kwargs_list = [

--- a/mpl_interactions/pyplot.py
+++ b/mpl_interactions/pyplot.py
@@ -447,14 +447,19 @@ def interactive_scatter(
         Valid input to plt.scatter or a function
     s : float, array-like, function, or index controls object
         valid input to plt.scatter, or a function
-    alpha : float, None, or function(s), broadcastable
+    vmin, vmax : float, callable, shorthand for slider or indexed controls
+        The vmin, vmax values for the colormap. Can accept a float for a fixed value,
+        or any slider shorthand to control with a slider, or an indexed controls
+        object to use an existing slider, or an arbitrary function of the other
+        parameters.
+    alpha : float or Callable, optional
         Affects all scatter points. This will compound with any alpha introduced by
         the ``c`` argument
     marker : MarkerStyle, or Callable, optional
         The marker style or a function returning marker styles.
-    edgecolor[s] : callable or valid argument to scatter
+    edgecolors : callable or valid argument to scatter
         passed through to scatter.
-    facecolor[s] : callable or valid argument to scatter
+    facecolors : callable or valid argument to scatter
         Valid input to plt.scatter, or a function
     label : string
         Passed through to Matplotlib
@@ -485,12 +490,13 @@ def interactive_scatter(
         - False: no sliders
         - 'left': sliders on the left
         - 'right': sliders on the right
-
     controls : mpl_interactions.controller.Controls
         An existing controls object if you want to tie multiple plot elements to the same set of
         controls
     display_controls : boolean
         Whether the controls should display on creation. Ignored if controls is specified.
+    **kwargs:
+        Interpreted as widgets and remainder are passed through to `ax.scatter`.
 
     Returns
     -------
@@ -654,15 +660,23 @@ def interactive_imshow(
     X : function or image like
         If a function it must return an image-like object. See matplotlib.pyplot.imshow for the
         full set of valid options.
-    autoscale_cmap : bool
-        If True rescale the colormap for every function update. Will not update
-        if vmin and vmax are provided or if the returned image is RGB(A) like.
-        forwarded to matplotlib
     alpha : float, callable, shorthand for slider or indexed controls
         The alpha value of the image. Can accept a float for a fixed value,
         or any slider shorthand to control with a slider, or an indexed controls
         object to use an existing slider, or an arbitrary function of the other
         parameters.
+    vmin, vmax : float, callable, shorthand for slider or indexed controls
+        The vmin, vmax values for the colormap. Can accept a float for a fixed value,
+        or any slider shorthand to control with a slider, or an indexed controls
+        object to use an existing slider, or an arbitrary function of the other
+        parameters.
+    vmin_vmax : tuple of float
+        Used to generate a range slider for vmin and vmax. Should be given in range slider
+        notation: `("r", 0, 1)`.
+    autoscale_cmap : bool
+        If True rescale the colormap for every function update. Will not update
+        if vmin and vmax are provided or if the returned image is RGB(A) like.
+        forwarded to matplotlib
     ax : matplotlib axis, optional
         The axis on which to plot. If none the current axis will be used.
     slider_formats : None, string, or dict
@@ -686,6 +700,8 @@ def interactive_imshow(
         controls
     display_controls : boolean
         Whether the controls should display on creation. Ignored if controls is specified.
+    **kwargs:
+        Interpreted as widgets and remainder are passed through to `ax.imshow`.
 
     Returns
     -------

--- a/mpl_interactions/pyplot.py
+++ b/mpl_interactions/pyplot.py
@@ -1266,7 +1266,8 @@ def interactive_text(
 
     .. note::
 
-        fontdict properties are currently static - see https://github.com/mpl-extensions/mpl-interactions/issues/247
+        fontdict properties are currently static
+        see https://github.com/mpl-extensions/mpl-interactions/issues/247
 
 
     Parameters

--- a/mpl_interactions/pyplot.py
+++ b/mpl_interactions/pyplot.py
@@ -417,7 +417,6 @@ def interactive_scatter(
     y=None,
     s=None,
     c=None,
-    cmap=None,
     vmin=None,
     vmax=None,
     alpha=None,
@@ -616,7 +615,6 @@ def interactive_scatter(
         s=s_,
         vmin=vmin,
         vmax=vmax,
-        cmap=cmap,
         marker=marker_,
         alpha=a_,
         edgecolors=ec_,
@@ -635,21 +633,11 @@ def interactive_scatter(
 # of `matplotlib.pyplot.imshow`
 def interactive_imshow(
     X,
-    cmap=None,
-    norm=None,
-    aspect=None,
-    interpolation=None,
     alpha=None,
     vmin=None,
     vmax=None,
     vmin_vmax=None,
-    origin=None,
-    extent=None,
     autoscale_cmap=True,
-    filternorm=True,
-    filterrad=4.0,
-    resample=None,
-    url=None,
     ax=None,
     slider_formats=None,
     force_ipywidgets=False,
@@ -666,23 +654,9 @@ def interactive_imshow(
     X : function or image like
         If a function it must return an image-like object. See matplotlib.pyplot.imshow for the
         full set of valid options.
-    cmap : str or `~matplotlib.colors.Colormap`
-        The Colormap instance or registered colormap name used to map
-        scalar data to colors. This parameter is ignored for RGB(A) data.
-        forwarded to matplotlib
-    norm : `~matplotlib.colors.Normalize`, optional
-        The `~matplotlib.colors.Normalize` instance used to scale scalar data to the [0, 1]
-        range before mapping to colors using *cmap*. By default, a linear
-        scaling mapping the lowest value to 0 and the highest to 1 is used.
-        This parameter is ignored for RGB(A) data.
-        forwarded to matplotlib
     autoscale_cmap : bool
         If True rescale the colormap for every function update. Will not update
         if vmin and vmax are provided or if the returned image is RGB(A) like.
-        forwarded to matplotlib
-    aspect : {'equal', 'auto'} or float
-        forwarded to matplotlib
-    interpolation : str
         forwarded to matplotlib
     alpha : float, callable, shorthand for slider or indexed controls
         The alpha value of the image. Can accept a float for a fixed value,
@@ -707,7 +681,6 @@ def interactive_imshow(
         - False: no sliders
         - 'left': sliders on the left
         - 'right': sliders on the right
-
     controls : mpl_interactions.controller.Controls
         An existing controls object if you want to tie multiple plot elements to the same set of
         controls
@@ -777,19 +750,9 @@ def interactive_imshow(
     sca(ax)
     im = ax.imshow(
         new_data,
-        cmap=cmap,
-        norm=norm,
-        aspect=aspect,
-        interpolation=interpolation,
         alpha=callable_else_value_no_cast(alpha, param_excluder(params, "alpha")),
         vmin=callable_else_value_no_cast(vmin, param_excluder(params, "vmin")),
         vmax=callable_else_value_no_cast(vmax, param_excluder(params, "vmax")),
-        origin=origin,
-        extent=extent,
-        filternorm=filternorm,
-        filterrad=filterrad,
-        resample=resample,
-        url=url,
         **imshow_kwargs,
     )
 


### PR DESCRIPTION
closes #167 

A nice follow up could be to break `axes` and `names` out into actual arguments rather than hiding them in kwargs. Also need to invesitgate what happens if you give both `names` and `axes` with names in it.